### PR TITLE
Fix VNC on Vagrant setup

### DIFF
--- a/classes/system/nova/compute/single.yml
+++ b/classes/system/nova/compute/single.yml
@@ -8,7 +8,7 @@ parameters:
       virtualization: kvm
       vncproxy_url: http://${_param:control_address}:6080
       bind:
-        vnc_address: ${_param:control_address}
+        vnc_address: ${_param:single_address}
         vnc_port: 6080
         vnc_name: 0.0.0.0
       database:


### PR DESCRIPTION
vncserver_proxyclient_address should point to compute's IP (Currently pointing to controller's IP)
